### PR TITLE
Set 429 sleep time to 3600 and local sleep time to 2

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -58,7 +58,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20180827.01'
+VERSION = '20180922.01'
 USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'quizlet'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/pipeline.py
+++ b/pipeline.py
@@ -58,7 +58,7 @@ if not WGET_LUA:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20180922.01'
+VERSION = '20180922.02'
 USER_AGENT = 'ArchiveTeam'
 TRACKER_ID = 'quizlet'
 TRACKER_HOST = 'tracker.archiveteam.org'

--- a/quizlet.lua
+++ b/quizlet.lua
@@ -22,7 +22,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     io.stdout:write("Server returned "..http_stat.statcode.." ("..err.."). Sleeping.\n")
     io.stdout:flush()
     if status_code == 429 then
-      os.execute("sleep 300")
+      os.execute("sleep 3600")
       return wget.actions.ABORT
     else
       os.execute("sleep 1")
@@ -40,7 +40,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
 
   tries = 0
 
-  local sleep_time = 1
+  local sleep_time = 2
 
   if sleep_time > 0.001 then
     os.execute("sleep " .. sleep_time)

--- a/quizlet.lua
+++ b/quizlet.lua
@@ -40,7 +40,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
 
   tries = 0
 
-  local sleep_time = 0
+  local sleep_time = 1
 
   if sleep_time > 0.001 then
     os.execute("sleep " .. sleep_time)


### PR DESCRIPTION
Due to the Warrior's default concurrency of 2, this should help the rate-limiting issue and also stop the pipeline from eating items